### PR TITLE
Update the blueapi client to return a plan result

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     "PyQt6 < 6.10.0",
     "pydantic",
     "aiohttp",
-    "blueapi",
+    "blueapi >= 1.12.0", # Minimum version to get plan result
 ] # Add project dependencies here, e.g. ["click", "numpy"]
 dynamic = ["version"]
 license.file = "LICENSE"

--- a/src/i19serial_ui/blueapi_tools/blueapi_client.py
+++ b/src/i19serial_ui/blueapi_tools/blueapi_client.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Any
 
 from blueapi.client.client import BlueapiClient
-from blueapi.client.rest import BlueskyRemoteControlError
+from blueapi.client.rest import BlueskyRemoteControlError, ServiceUnavailableError
 from blueapi.config import ApplicationConfig, ConfigLoader
 from blueapi.service.model import TaskRequest
 
@@ -34,6 +34,23 @@ class SerialBlueapiClient:
         config = self._load_config_from_file(config_file)
         return BlueapiClient.from_config(config)
 
+    def _create_task(self, plan_name: str, plan_params: dict[str, Any]) -> TaskRequest:
+        return TaskRequest(
+            name=plan_name,
+            params=plan_params,
+            instrument_session=self.instrument_session,
+        )
+
+    def _check_instrument_session(self) -> bool:
+        if not self.instrument_session:
+            log_to_gui(
+                LOGGER,
+                "Instrument session hasn't been set, please select visit before continuing.",  # noqa: E501
+                level="ERROR",
+            )
+            return False
+        return True
+
     def update_session(self, new_session: str):
         self.instrument_session = new_session
         log_to_gui(LOGGER, f"Session updated: {self.instrument_session}")
@@ -46,16 +63,50 @@ class SerialBlueapiClient:
             log_to_gui(LOGGER, "Abort: Nothing seems to be running.")
 
     def run_plan(self, plan_name: str, plan_params: dict[str, Any]):
-        if not self.instrument_session:
-            log_to_gui(
-                LOGGER,
-                "Instrument session hasn't been set, please select visit before continuing.",  # noqa: E501
-                level="ERROR",
-            )
-            return
-        task = TaskRequest(
-            name=plan_name,
-            params=plan_params,
-            instrument_session=self.instrument_session,
-        )
-        self.client.create_and_start_task(task)
+        if self._check_instrument_session():
+            task = self._create_task(plan_name, plan_params)
+            try:
+                self.client.create_and_start_task(task)
+            except Exception as e:
+                log_to_gui(
+                    LOGGER,
+                    f"""Something went wrong running the {plan_name} plan,
+                    check out the logs for more information""",
+                    level="ERROR",
+                )
+                LOGGER.exception(e)
+        log_to_gui(LOGGER, "Run plan done", level="DEBUG")
+
+    def run_plan_and_get_result(
+        self, plan_name: str, plan_params: dict[str, Any]
+    ) -> Any | None:
+        res = None
+        if self._check_instrument_session():
+            task = self._create_task(plan_name, plan_params)
+            try:
+                task_result = self.client.run_task(task)
+            except ServiceUnavailableError as e:
+                log_to_gui(
+                    LOGGER, f"Error creating task for plan {plan_name}", level="ERROR"
+                )
+                LOGGER.exception(e)
+            except Exception as e:
+                log_to_gui(
+                    LOGGER,
+                    f"""Something went wrong running the {plan_name} plan,
+                    check out the logs for more information""",
+                    level="ERROR",
+                )
+                LOGGER.exception(e)
+            if task_result.task_failed:
+                log_to_gui(
+                    LOGGER,
+                    f"Task returns failed while running {plan_name}",
+                    level="ERROR",
+                )
+                if task_result.result:
+                    LOGGER.error(task_result.result.model_dump())
+            else:
+                res = task_result.result.result  # type: ignore
+        log_to_gui(LOGGER, "Run plan with result done", level="DEBUG")
+        return res

--- a/tests/blueapi_client/test_client.py
+++ b/tests/blueapi_client/test_client.py
@@ -1,9 +1,11 @@
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from blueapi.client.client import BlueapiClient
 from blueapi.config import ApplicationConfig
+from blueapi.service.model import TaskRequest
+from blueapi.worker.event import TaskResult, TaskStatus
 
 from i19serial_ui.blueapi_tools.blueapi_client import (
     SerialBlueapiClient,
@@ -32,11 +34,32 @@ def test_run_plan_exits_with_error_message_if_no_instrument_session(
 ):
     mock_client.run_plan("some_plan", {})
 
-    patch_log.assert_called_once_with(
-        patch_logger,
-        "Instrument session hasn't been set, please select visit before continuing.",
-        level="ERROR",
-    )
+    expected_log_calls = [
+        call(
+            patch_logger,
+            "Instrument session hasn't been set, please select visit before continuing.",  # noqa: E501
+            level="ERROR",
+        ),
+        call(
+            patch_logger,
+            "Run plan done",
+            level="DEBUG",
+        ),
+    ]
+
+    patch_log.assert_has_calls(expected_log_calls)
+
+
+@pytest.mark.parametrize("session, expected_result", [("", False), ("cm12345-1", True)])
+def test_check_instrument_session(
+    session: str,
+    expected_result: bool,
+    mock_client: SerialBlueapiClient,
+):
+    mock_client.update_session(session)
+    check_result = mock_client._check_instrument_session()
+
+    assert check_result is expected_result
 
 
 @patch("i19serial_ui.blueapi_tools.blueapi_client.log_to_gui")
@@ -46,6 +69,16 @@ def test_client_update_session(patch_log: MagicMock, mock_client: SerialBlueapiC
     mock_client.update_session("cm12345-1")
     assert mock_client.instrument_session == "cm12345-1"
     patch_log.assert_called_once()
+
+
+def test_client_create_task(mock_client: SerialBlueapiClient):
+    mock_client.update_session("cm12345-1")
+    task = mock_client._create_task("new_plan", {"x": 10})
+
+    assert isinstance(task, TaskRequest)
+    assert task.name == "new_plan"
+    assert task.params == {"x": 10}
+    assert task.instrument_session == "cm12345-1"
 
 
 def test_run_plan(mock_client: SerialBlueapiClient):
@@ -60,3 +93,32 @@ def test_run_plan(mock_client: SerialBlueapiClient):
 def test_client_error_if_config_file_not_yaml():
     with pytest.raises(WrongConfigFileFormatError):
         SerialBlueapiClient(Path("some_file.csv"))
+
+
+@pytest.mark.parametrize(
+    "failure, result, expected_result", [(False, "Hello", "Hello"), (True, "", None)]
+)
+def test_run_plan_and_get_its_result(
+    failure: bool,
+    result: str,
+    expected_result: str | None,
+    mock_client: SerialBlueapiClient,
+):
+    mock_client.client = MagicMock(spec=BlueapiClient)
+    mock_client.client.run_task.return_value = TaskStatus(
+        task_id="abcd",
+        result=TaskResult(outcome="success", result=result, type="string"),
+        task_complete=True,
+        task_failed=failure,
+    )
+
+    mock_client.update_session("cm12345-1")
+    res = mock_client.run_plan_and_get_result("some_plan", {"param": 1})
+
+    mock_client.client.run_task.assert_called_once_with(
+        TaskRequest(
+            name="some_plan", params={"param": 1}, instrument_session="cm12345-1"
+        )
+    )
+
+    assert res == expected_result


### PR DESCRIPTION
In newer versions of blueapi it is possible to easily get the plan result from the run_engine without having to interrogate the documents.
This PR pins blueapi to the first version where this was enabled and adds a method to make use of this.